### PR TITLE
Satisfy Deprecation Cop

### DIFF
--- a/lib/serial-view.coffee
+++ b/lib/serial-view.coffee
@@ -20,7 +20,7 @@ module.exports =
 			atom.workspace.open('Serial Monitor').then (editor) =>
 				@editor = editor
 				@editor.setText ''
-				@editorView = @editor.editorElement
+				@editorView = @editor.element
 				
 				div = document.createElement 'div'
 				div.className = 'arduino-upload-serial'


### PR DESCRIPTION
Proposed change to satisfy Atom's Deprecation Cop because apparently `.editorElement` is to be removed in a later build and can currently be replaced with `.element`