### PR TITLE
Save all active tabs before build and upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 npm-debug.log
 node_modules
+screenshots

--- a/lib/arduino-upload.coffee
+++ b/lib/arduino-upload.coffee
@@ -139,6 +139,8 @@ module.exports = ArduinoUpload =
 		isArduino = fs.existsSync file
 		return {isArduino, workpath, file, name}
 	_build: (options, callback, onerror, port = false) ->
+		@closeserial()
+		atom.commands.dispatch(atom.views.getView(atom.workspace.getActiveTextEditor()), 'window:save-all')
 		{isArduino, workpath, file, name} = @isArduinoProject()
 		if not isArduino
 			atom.notifications.addError "File isn't part of an Arduino sketch!"
@@ -188,8 +190,6 @@ module.exports = ArduinoUpload =
 			callback code, info
 			output.finish()
 	build: (keep) ->
-		@closeserial()
-		atom.commands.dispatch(atom.views.getView(atom.workspace.getActiveTextEditor()), 'window:save-all')
 		@_build ['--verify'], (code, info) =>
 			if code != false
 				if code != 0
@@ -199,8 +199,6 @@ module.exports = ArduinoUpload =
 						fs.createReadStream(info.buildFolder + info.name + ending).pipe(fs.createWriteStream(info.workpath + seperator + info.name + ending))
 		
 	upload: ->
-		@closeserial()
-		atom.commands.dispatch(atom.views.getView(atom.workspace.getActiveTextEditor()), 'window:save-all')
 		@getPort (port) =>
 			if port == ''
 				atom.notifications.addError 'No arduino connected'

--- a/lib/arduino-upload.coffee
+++ b/lib/arduino-upload.coffee
@@ -154,8 +154,10 @@ module.exports = ArduinoUpload =
 		isArduino = fs.existsSync file
 		return {isArduino, workpath, file, name}
 	_build: (options, callback, onerror, port = false) ->
-		if atom.config.get('arduino-upload.autosave') == 'save' or 'save+reopen'
-			if atom.config.get('arduino-upload.autosave') == 'save+reopen'
+		serialWasOpen = false
+		autosaveConf = atom.config.get('arduino-upload.autosave')
+		if (autosaveConf == 'save') || (autosaveConf == 'save+reopen')
+			if autosaveConf == 'save+reopen'
 				if serial != null
 					serialWasOpen = true
 				else
@@ -210,8 +212,7 @@ module.exports = ArduinoUpload =
 			}
 			callback code, info
 			output.finish()
-			if atom.config.get('arduino-upload.autosave') == 'save+reopen'
-				if serialWasOpen
+			if (autosaveConf == 'save+reopen') && (serialWasOpen)
 					@openserial()
 	build: (keep) ->
 		@_build ['--verify'], (code, info) =>

--- a/lib/arduino-upload.coffee
+++ b/lib/arduino-upload.coffee
@@ -188,6 +188,8 @@ module.exports = ArduinoUpload =
 			callback code, info
 			output.finish()
 	build: (keep) ->
+		@closeserial()
+		atom.commands.dispatch(atom.views.getView(atom.workspace.getActiveTextEditor()), 'window:save-all')
 		@_build ['--verify'], (code, info) =>
 			if code != false
 				if code != 0
@@ -197,6 +199,8 @@ module.exports = ArduinoUpload =
 						fs.createReadStream(info.buildFolder + info.name + ending).pipe(fs.createWriteStream(info.workpath + seperator + info.name + ending))
 		
 	upload: ->
+		@closeserial()
+		atom.commands.dispatch(atom.views.getView(atom.workspace.getActiveTextEditor()), 'window:save-all')
 		@getPort (port) =>
 			if port == ''
 				atom.notifications.addError 'No arduino connected'

--- a/lib/arduino-upload.coffee
+++ b/lib/arduino-upload.coffee
@@ -59,6 +59,11 @@ module.exports = ArduinoUpload =
 			default: 1
 			minimum: 0
 			maximum: 3
+		autoSave:
+			title: 'Autosave all active tabs before building/uploading.'
+			description: 'This will auto close the "Serial Monitor" tab and save everything before building/uploading.'
+			type: 'boolean'
+			default: 'false'
 	vendorsArduino: {
 		0x2341: true # Arduino
 		0x2a03: true # Arduino M0 Pro (perhaps other devices?)
@@ -139,8 +144,9 @@ module.exports = ArduinoUpload =
 		isArduino = fs.existsSync file
 		return {isArduino, workpath, file, name}
 	_build: (options, callback, onerror, port = false) ->
-		@closeserial()
-		atom.commands.dispatch(atom.views.getView(atom.workspace.getActiveTextEditor()), 'window:save-all')
+		if atom.config.get('arduino-upload.autoSave')
+			@closeserial()
+			atom.commands.dispatch(atom.views.getView(atom.workspace.getActiveTextEditor()), 'window:save-all')
 		{isArduino, workpath, file, name} = @isArduinoProject()
 		if not isArduino
 			atom.notifications.addError "File isn't part of an Arduino sketch!"

--- a/lib/arduino-upload.coffee
+++ b/lib/arduino-upload.coffee
@@ -9,7 +9,6 @@ SerialView = require './serial-view'
 tmp = require 'tmp'
 { seperator, getArduinoPath } = require './util'
 Boards = require './boards'
-serialOpen = false
 
 try
 	serialport = require 'serialport-builds-electron'
@@ -335,7 +334,6 @@ module.exports = ArduinoUpload =
 
 			@_openserialport(port)
 	openserial: ->
-		serialOpen = true
 		if serialport == null
 			atom.notifications.addInfo 'Serialport dependency not present, try installing it! (And, if you figure out how, please report me how <a href="https://github.com/Sorunome/arduino-upload/issues">here</a> as I don\'t know how to do it..... Really, <b>please</b> help me! D: )'
 			return
@@ -350,7 +348,6 @@ module.exports = ArduinoUpload =
 				serial?.write s
 			@openserialport()
 	closeserial: ->
-		serialOpen = false
 		serial?.close (err) ->
 			return
 		serial = null

--- a/lib/arduino-upload.coffee
+++ b/lib/arduino-upload.coffee
@@ -40,36 +40,37 @@ module.exports = ArduinoUpload =
 	config:
 		arduinoExecutablePath:
 			title: 'Arduino Executable Path'
-			description: 'The location of the arduino IDE executable, your PATH is being searched, too'
+			description: '''The location of the arduino IDE executable, your PATH is
+			being searched, too'''
 			type: 'string'
 			default: 'arduino'
-		autoSaveStuff:
+		autosave:
 			title: 'Autosave'
-			type: 'object'
-			properties:
-				autoSave:
-					title: 'Autosave all tabs before building, verifying, and uploading'
-					description: 'This will auto close the Serial Monitor tab and save everything before building/uploading.'
-					type: 'boolean'
-					default: 'false'
-				serialReopen:
-					title: 'Automatically reopen serial monitor'
-					description: 'This setting toggles wether or not the Serial Monitor should be re-opened automatically.'
-					type: 'boolean'
-					default: 'false'
+			description: '''Enabeles autosaving before building, uploading, or verifying.
+			If the serial monitor is open and `save` is selected the serial monitor will
+			quit to avoid saving its output when performing the aforementioned producers.
+			The serial monitor can be made to automatically reopened afterwards through the
+			setting `save+reopen`'''
+			type: 'string'
+			default: 'disabled'
+			enum: ['disabled', 'save', 'save+reopen']
 		baudRate:
 			title: 'BAUD Rate'
-			description: 'Sets the BAUD rate for the serial monitor, if you change it you need to close and open it manually'
+			description: '''Sets the BAUD rate for the serial monitor, if you change
+			it you need to close and open it manually'''
 			type: 'number'
 			default: '9600'
 		board:
 			title: 'Arduino board'
-			description: 'If kept blank, it will take the settings from the arduino IDE. The board uses the pattern as described <a href="https://github.com/arduino/Arduino/blob/ide-1.5.x/build/shared/manpage.adoc#options">here</a>'
+			description: '''If kept blank, it will take the settings from the arduino
+			IDE. The board uses the pattern as described
+			<a href="https://github.com/arduino/Arduino/blob/ide-1.5.x/build/shared/manpage.adoc#options">here</a>'''
 			type: 'string'
 			default: ''
 		lineEnding:
 			title: 'Default line ending in serial monitor'
-			description: '0 - No line ending<br>1 - Newline<br>2 - Carriage return<br>3 - Both NL &amp; CR'
+			description: '''0 - No line ending<br>1 - Newline<br>2 - Carriage return
+			<br>3 - Both NL &amp; CR'''
 			type: 'integer'
 			default: 1
 			minimum: 0
@@ -154,11 +155,12 @@ module.exports = ArduinoUpload =
 		isArduino = fs.existsSync file
 		return {isArduino, workpath, file, name}
 	_build: (options, callback, onerror, port = false) ->
-		if atom.config.get('arduino-upload.autoSaveStuff.autoSave')
-			if serialOpen
-				serialWasOpen = true
-			else
-				serialWasOpen = false
+		if atom.config.get('arduino-upload.autosave') == 'save' or 'save+reopen'
+			if atom.config.get('arduino-upload.autosave') == 'save+reopen'
+				if serial != null
+					serialWasOpen = true
+				else
+					serialWasOpen = false
 			@closeserial()
 			atom.commands.dispatch(atom.views.getView(atom.workspace.getActiveTextEditor()), 'window:save-all')
 		{isArduino, workpath, file, name} = @isArduinoProject()
@@ -209,8 +211,9 @@ module.exports = ArduinoUpload =
 			}
 			callback code, info
 			output.finish()
-			if serialWasOpen && atom.config.get('arduino-upload.autoSaveStuff.serialReopen') && atom.config.get('arduino-upload.autoSaveStuff.autoSave')
-				@openserial()
+			if atom.config.get('arduino-upload.autosave') == 'save+reopen'
+				if serialWasOpen
+					@openserial()
 	build: (keep) ->
 		@_build ['--verify'], (code, info) =>
 			if code != false

--- a/lib/arduino-upload.coffee
+++ b/lib/arduino-upload.coffee
@@ -42,6 +42,11 @@ module.exports = ArduinoUpload =
 			description: 'The location of the arduino IDE executable, your PATH is being searched, too'
 			type: 'string'
 			default: 'arduino'
+		autoSave:
+			title: 'Autosave all active tabs before building/uploading.'
+			description: 'This will auto close the "Serial Monitor" tab and save everything before building/uploading.'
+			type: 'boolean'
+			default: 'false'
 		baudRate:
 			title: 'BAUD Rate'
 			description: 'Sets the BAUD rate for the serial monitor, if you change it you need to close and open it manually'
@@ -59,11 +64,6 @@ module.exports = ArduinoUpload =
 			default: 1
 			minimum: 0
 			maximum: 3
-		autoSave:
-			title: 'Autosave all active tabs before building/uploading.'
-			description: 'This will auto close the "Serial Monitor" tab and save everything before building/uploading.'
-			type: 'boolean'
-			default: 'false'
 	vendorsArduino: {
 		0x2341: true # Arduino
 		0x2a03: true # Arduino M0 Pro (perhaps other devices?)

--- a/lib/arduino-upload.coffee
+++ b/lib/arduino-upload.coffee
@@ -157,11 +157,8 @@ module.exports = ArduinoUpload =
 		serialWasOpen = false
 		autosaveConf = atom.config.get('arduino-upload.autosave')
 		if (autosaveConf == 'save') || (autosaveConf == 'save+reopen')
-			if autosaveConf == 'save+reopen'
-				if serial != null
-					serialWasOpen = true
-				else
-					serialWasOpen = false
+			if (autosaveConf == 'save+reopen') && (serial != null)
+				serialWasOpen = true
 			@closeserial()
 			atom.commands.dispatch(atom.views.getView(atom.workspace.getActiveTextEditor()), 'window:save-all')
 		{isArduino, workpath, file, name} = @isArduinoProject()


### PR DESCRIPTION
Proposing the change to run window:save-all command before beginning the upload or building process. Unfortunately this needs to close the serial monitor to avoid saving its output in the project directory. Resolves #37 