### PR TITLE
Support for USBtinyISP clones

### DIFF
--- a/lib/arduino-upload.coffee
+++ b/lib/arduino-upload.coffee
@@ -85,6 +85,7 @@ module.exports = ArduinoUpload =
 	}
 	vendorsProgrammer: {
 		0x03eb: [ 0x2141 ] # Atmel ICE debugger
+		0x1781: [ 0x0c9f ] # USBtinyISP Clones
 	}
 	buildFolders: []
 	activate: (state) ->


### PR DESCRIPTION
Added USB vendor and device ID for USBtinyISP clones
https://www.sparkfun.com/products/9825
https://github.com/sparkfun/Pocket_AVR_Programmer/blob/master/Firmware/pocket-prog/spi/usbtiny.h
#define	USBTINY_VENDOR_ID		0x1781 // SparkFun Licensed VendorID
#define	USBTINY_DEVICE_ID		0x0C9F // SparkFun Licensed ProductID
also
https://www.tindie.com/products/nsayer/usb-isp/