### PR TITLE
Added toolbar setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Are you on windows and can't install because of the serialport package? Try inst
 * `arduino-upload:upload` - Uploads the current sketch to a connected arduino
 * `arduino-upload:serial-monitor` - Opens the serial monitor of a connected arduino
 
+You can place these commands in a toolbar using the [**Flex Tool Bar**](https://atom.io/packages/flex-tool-bar) package. [Here's how](docs/toolbar.md).
+
 ## Screenshots
 Verifying a program:  
 ![verify](https://github.com/Sorunome/arduino-upload/blob/master/screenshots/verify.gif?raw=true)

--- a/docs/toolbar.md
+++ b/docs/toolbar.md
@@ -1,0 +1,43 @@
+# Arduino Upload Package
+
+## Add a toolbar
+
+You can install `tool-bar` and `flex-tool-bar` Atom packages and use them to add a toolbar for Arduino commands, similar to the one in the official IDE.
+
+	apm install tool-bar
+	apm install flex-tool-bar
+	
+The following is an example for the Flex Tool Bar's configuration file, `toolbar.cson`. It adds the buttons for Arduino **Verify** and **Upload** commands (automatically saving the current file before), and another to open the **Serial Monitor**.
+
+	[
+	  {
+		type: "button"
+		icon: "check"
+		callback: ["core:save", "arduino-upload:verify"]
+		tooltip: "Arduino: Verify",
+		enable: { grammar: "arduino" }
+	  }
+	  {
+		type: "button"
+		icon: "arrow-right"
+		callback: ["core:save", "arduino-upload:upload"]
+		tooltip: "Arduino: Upload",
+		enable: { grammar: "arduino" }
+	  }
+	  {
+		type: "button"
+		icon: "terminal"
+		callback: "arduino-upload:serial-monitor"
+		tooltip: "Arduino: Serial monitor",
+		enable: { grammar: "arduino" }
+	  }
+	  {
+		type: "spacer"
+	  }
+	  {
+		type: "button"
+		icon: "gear"
+		callback: "flex-tool-bar:edit-config-file"
+		tooltip: "Edit Tool Bar"
+	  }
+	]

--- a/docs/toolbar.md
+++ b/docs/toolbar.md
@@ -9,39 +9,41 @@ You can install `tool-bar` and `flex-tool-bar` Atom packages and use them to add
 	
 The following is an example for the Flex Tool Bar's configuration file, `toolbar.cson`. It adds the buttons for Arduino **Verify** and **Upload** commands (automatically saving the current file before), and another to open the **Serial Monitor**.
 
-	[
-	  {
-		type: "button"
-		icon: "check"
-		callback: ["core:save", "arduino-upload:verify"]
-		tooltip: "Arduino: Verify",
-		enable: { grammar: "arduino" }
-	  }
-	  {
-		type: "button"
-		icon: "arrow-right"
-		callback: ["core:save", "arduino-upload:upload"]
-		tooltip: "Arduino: Upload",
-		enable: { grammar: "arduino" }
-	  }
-	  {
-		type: "button"
-		icon: "terminal"
-		callback: "arduino-upload:serial-monitor"
-		tooltip: "Arduino: Serial monitor",
-		enable: { grammar: "arduino" }
-	  }
-	  {
-		type: "spacer"
-	  }
-	  {
-		type: "button"
-		icon: "gear"
-		callback: "flex-tool-bar:edit-config-file"
-		tooltip: "Edit Tool Bar"
-	  }
-	]
-	
+```coffeescript
+[
+  {
+	type: "button"
+	icon: "check"
+	callback: ["core:save", "arduino-upload:verify"]
+	tooltip: "Arduino: Verify",
+	enable: { grammar: "arduino" }
+  }
+  {
+	type: "button"
+	icon: "arrow-right"
+	callback: ["core:save", "arduino-upload:upload"]
+	tooltip: "Arduino: Upload",
+	enable: { grammar: "arduino" }
+  }
+  {
+	type: "button"
+	icon: "terminal"
+	callback: "arduino-upload:serial-monitor"
+	tooltip: "Arduino: Serial monitor",
+	enable: { grammar: "arduino" }
+  }
+  {
+	type: "spacer"
+  }
+  {
+	type: "button"
+	icon: "gear"
+	callback: "flex-tool-bar:edit-config-file"
+	tooltip: "Edit Tool Bar"
+  }
+]
+```
+
 Here's the result:
 
 ![Arduino Upload Atom toolbar screenshot](http://i.imgur.com/TdbZN9r.png)

--- a/docs/toolbar.md
+++ b/docs/toolbar.md
@@ -41,3 +41,7 @@ The following is an example for the Flex Tool Bar's configuration file, `toolbar
 		tooltip: "Edit Tool Bar"
 	  }
 	]
+	
+Here's the result:
+
+![Arduino Upload Atom toolbar screenshot](http://i.imgur.com/TdbZN9r.png)


### PR DESCRIPTION
This is very useful because:

1) It makes the transition from the official IDE less harsh.
2) It fixes the hassle of having to save before build.