### PR TITLE
Fixed invalid CSON indentation in the toolbar configuration snippet

### DIFF
--- a/docs/toolbar.md
+++ b/docs/toolbar.md
@@ -12,34 +12,34 @@ The following is an example for the Flex Tool Bar's configuration file, `toolbar
 ```coffeescript
 [
   {
-	type: "button"
-	icon: "check"
-	callback: ["core:save", "arduino-upload:verify"]
-	tooltip: "Arduino: Verify",
-	enable: { grammar: "arduino" }
+    type: "button"
+    icon: "check"
+    callback: ["core:save", "arduino-upload:verify"]
+    tooltip: "Arduino: Verify",
+    enable: { grammar: "arduino" }
   }
   {
-	type: "button"
-	icon: "arrow-right"
-	callback: ["core:save", "arduino-upload:upload"]
-	tooltip: "Arduino: Upload",
-	enable: { grammar: "arduino" }
+    type: "button"
+    icon: "arrow-right"
+    callback: ["core:save", "arduino-upload:upload"]
+    tooltip: "Arduino: Upload",
+    enable: { grammar: "arduino" }
   }
   {
-	type: "button"
-	icon: "terminal"
-	callback: "arduino-upload:serial-monitor"
-	tooltip: "Arduino: Serial monitor",
-	enable: { grammar: "arduino" }
+    type: "button"
+    icon: "terminal"
+    callback: "arduino-upload:serial-monitor"
+    tooltip: "Arduino: Serial monitor",
+    enable: { grammar: "arduino" }
   }
   {
-	type: "spacer"
+    type: "spacer"
   }
   {
-	type: "button"
-	icon: "gear"
-	callback: "flex-tool-bar:edit-config-file"
-	tooltip: "Edit Tool Bar"
+    type: "button"
+    icon: "gear"
+    callback: "flex-tool-bar:edit-config-file"
+    tooltip: "Edit Tool Bar"
   }
 ]
 ```


### PR DESCRIPTION
Somewhere in the copy-paste process, tabs appeared out of nowhere, breaking the example CSON indentation in the toolbar configuration documentation. Sorry, my bad.