### PR TITLE
Serialport installed and everything updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 npm-debug.log
 node_modules
-screenshots
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Did you not like the look of the arduino IDE but were stuck with it nevertheless
 (Requires atom 1.10 or later)
 
 ## Troubleshooting
-* Are you on Windows and can't install because of the serialport package? Try installing the [Visual C++ 2015 building tools](https://github.com/felixrieseberg/windows-build-tools) by running `npm install --global --production windows-build-tools` from `%LocalAppData%\atom\app-<VERSION>\resources\apm\node_modules\npm\bin` (this uses atoms integrated npm instead of requiring an external instance). Then update apm config with `apm config set msvs_version [VERSION]` (the version installed by the tool should be 2015) and `apm config set python [PATH]\python.exe` (where PATH is the path to the python executable).
+* Are you on Windows and can't install because of the serialport package? Try installing the [Visual C++ 2015 building tools](https://github.com/felixrieseberg/windows-build-tools) by running `.\npm install --global --production windows-build-tools` from `%LocalAppData%\atom\app-[VERSION]\resources\app\apm\bin` in an adminastrative PowerShell (this uses atoms integrated npm instead of requiring an external instance). Then update apm config with `apm config set msvs_version [VERSION]` (the version installed by the tool should be 2015) and `apm config set python [PATH]\python.exe` (where PATH is the path to the python executable).
 * The verify/build output does not appear? Make sure your Arduino official IDE language is set to English.
 
 ## Available commands

--- a/lib/arduino-upload.coffee
+++ b/lib/arduino-upload.coffee
@@ -11,7 +11,7 @@ tmp = require 'tmp'
 Boards = require './boards'
 
 try
-	serialport = require 'serialport-builds-electron'
+	serialport = require 'serialport'
 catch e
 	serialport = null
 try
@@ -295,10 +295,10 @@ module.exports = ArduinoUpload =
 	serialNormalClose: true
 	_openserialport: (port, start = true)->
 		try
-			serial = new serialport.SerialPort port, {
-					baudRate: atom.config.get('arduino-upload.baudRate')
-					parser: serialport.parsers.raw
-				}
+			serialport serial = new serialport(port, {
+						baudRate: atom.config.get('arduino-upload.baudRate')
+						parser: serialport.parsers.raw
+					});
 			@serialNormalClose = true
 			serial.on 'open', (data) =>
 				if start

--- a/package.json
+++ b/package.json
@@ -13,22 +13,20 @@
   "repository": "https://github.com/Sorunome/arduino-upload",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.0.0 <2.0.0"
+    "atom": ">=1.0.0"
   },
   "consumedServices": {
     "status-bar": {
       "versions": {
-        "^1.0.0": "consumeStatusBar"
+        ">=1.0.0": "consumeStatusBar"
       }
     }
   },
   "dependencies": {
     "atom-space-pen-views": ">=2.0.3",
-    "bluebird": "^3.5.0",
-    "serialport-builds-electron": "^4.0.7",
-    "tmp": ">=0.0.31"
-  },
-  "optionalDependencies": {
-    "usb-detection": ">=1.4.0"
+    "bluebird": ">=3.5.0",
+    "serialport": ">=7.0.2",
+    "tmp": ">=0.0.31",
+    "usb-detection": ">=3.0.0"
   }
 }


### PR DESCRIPTION
- Pushed all versions to latest and migrated to the official serialport package instead of your custom one.
- Made usb-detection a standard dependency (it's obviously required).
- Added package-lock.json to the .gitignore so it doesn't interfere with `apm install`. Also removed screenshots from it because I had made a mistake earlier.
- Fixed my troubleshooting section

Confirmed working on Windows 10 and the latest version of Arch Linux.

This closes #55, closes #52, closes #43, closes #39, closes #41, closes #32, and closes #30.

This patch also makes the package somewhat of a rolling release, so it should function until a major update to one of the dependencies takes it out, in which case its dependency version can be updated to lock it in a state just before breaking.