### PR TITLE
Organise boards selector: spacer between board families

### DIFF
--- a/lib/boards.coffee
+++ b/lib/boards.coffee
@@ -131,13 +131,23 @@ module.exports =
 			
 			op = new Option()
 			op.value = ''
-			op.text = '== Arduino Setting =='
+			op.text = 'Use Arduino IDE Setting'
 			@selectNode.options.add op
-			op = new Option()
-			op.value = 'ignore'
-			op.text = '== Custom Setting =='
-			@selectNode.options.add op
+			prev_family = ''
 			for board of @boards
+				family = board.split(':')[0]
+				if family != prev_family
+					prev_family = family
+					# Separator to make families stand out
+					op = new Option()
+					op.value = 'ignore'
+					op.text = ''
+					@selectNode.options.add op
+					# Family name.
+					op = new Option()
+					op.value = 'ignore'
+					op.text = '[' + family.toUpperCase() + ']'
+					@selectNode.options.add op
 				op = new Option()
 				op.value = board
 				op.text = @boards[board]


### PR DESCRIPTION
This PR was not requested; feel free to suggest improvements, or to decline if you disagree with my changes. It was created because I always have trouble finding the right board in the long, flat and unsorted boards list. While I haven't implemented sorting (new to Coffeescript), I did add the following improvements which I find help me locate my boards quicker in the board selection:

* Adds board family name, uppercased, between the different board families (Arduino, ESP32, ESP8266)
* Adds a spacer between different board families to aid in locating the correct section
* Renames '== Arduino Setting ==' to more descriptive 'Use Arduino IDE Setting'
* Removes the redundant '== Custom Setting ==' entry.

Screenshots:

![screenshot from 2018-12-01 18-53-42](https://user-images.githubusercontent.com/570247/49331260-83cfc300-f59a-11e8-91f0-61b37cdee3f8.png)

![screenshot from 2018-12-01 18-53-46](https://user-images.githubusercontent.com/570247/49331261-83cfc300-f59a-11e8-8691-a2e84e47f0e7.png)

![screenshot from 2018-12-01 18-53-52](https://user-images.githubusercontent.com/570247/49331262-83cfc300-f59a-11e8-9593-ba06528dd818.png)


