### PR TITLE
Update to serialport 8.06

### DIFF
--- a/lib/arduino-upload.coffee
+++ b/lib/arduino-upload.coffee
@@ -268,12 +268,12 @@ module.exports = ArduinoUpload =
 					return true
 		return false
 	_getPort: (callback) ->
-		serialport.list (err, ports) =>
+		serialport.list().then (ports) =>
 			console.log ports
 			p = ''
 			for port in ports
 				if @isArduino(port.vendorId, port.productId)
-					p = port.comName
+					p = port.path;
 					break
 			callback p
 	getPort: (callback) ->

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	"dependencies": {
 		"atom-space-pen-views": ">=2.0.3",
 		"bluebird": ">=3.5.0",
-		"serialport": ">=7.0.2",
+		"serialport": ">=8.0.6",
 		"tmp": ">=0.0.31",
 		"usb-detection": ">=3.0.0"
 	}


### PR DESCRIPTION
Serialport v8 introduced [breaking 
changes](https://github.com/serialport/node-serialport/blob/master/UPGRADE_GUIDE.md) that break current installs of arduino-upload because serialport@8 is 
included in serialport>=7.0.2.