### PR TITLE
Updated usb-detection to fix install on Atom 1.39+ (#75)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
 		"bluebird": ">=3.5.0",
 		"serialport": ">=8.0.6",
 		"tmp": ">=0.0.31",
-		"usb-detection": ">=3.0.0"
+		"usb-detection": ">=4.8.0"
 	}
 }


### PR DESCRIPTION
Looks like the updated version of [`usb-detection`](https://github.com/MadLittleMods/node-usb-detection) fixed its [issue on Node 10+](https://github.com/MadLittleMods/node-usb-detection/issues/85#issuecomment-618750229). I tried updating the dependency here and I was able to rebuild `arduino-upload` on Atom 1.45.0, now it works.